### PR TITLE
[FIX] contour 객체 구조 field name, field type 변경

### DIFF
--- a/contours.py
+++ b/contours.py
@@ -1,6 +1,7 @@
 import pdb
 import numpy as np
 import cv2
+import json
 from shapely.geometry import Polygon
 
 
@@ -29,11 +30,11 @@ def generate_wkt_from_openapi(openapi_output, slide_height):
     min_area = 0
     if openapi_output["summary"]["score"] == "Benign":
         return wkt_list
-    contour_list = openapi_output["heatmap"]["contours"]
+    contour_list = json.loads(openapi_output["heatmap"]["contours"]) #DeepDx-HTTP-API 서비스에서 contour 객체의 contour field type = string
     
     for _contours in contour_list:
         contours = _contours['contour']
-        pattern = _contours['class']
+        pattern = _contours['label']
         rotate_list = []
         annotation = []
         for contour in contours:


### PR DESCRIPTION
https://app.clickup.com/t/35k5u1d 

GCP에 배포된 DeepDx-HTTP-API (OpenAPI) 서비스 업데이트 과정에서 기존에 cytomine에 연결하기 위해 작성한 코드에서 API Document 명세와 contour 객체 구조로 맞춰지면서 분석 결과  contour 객체의 구조가 바뀌었습니다.

https://docs.google.com/document/d/1tkMO9MH9gvotm5AQEU3MrtRJADA3CdWabezUHIQ3dgg/edit

field name( class -> label) 
field type (contour 는 array type -> string type)